### PR TITLE
removed ref from m_cryptoConfig field

### DIFF
--- a/aws-cpp-sdk-s3-encryption/include/aws/s3-encryption/S3EncryptionClient.h
+++ b/aws-cpp-sdk-s3-encryption/include/aws/s3-encryption/S3EncryptionClient.h
@@ -70,7 +70,7 @@ namespace Aws
 
             Aws::S3Encryption::Modules::CryptoModuleFactory m_cryptoModuleFactory;
             std::shared_ptr<Aws::Utils::Crypto::EncryptionMaterials> m_encryptionMaterials;
-            const Aws::S3Encryption::CryptoConfiguration& m_cryptoConfig;
+            const Aws::S3Encryption::CryptoConfiguration m_cryptoConfig;
         };
     }
 }


### PR DESCRIPTION
Without that fix S3EncryptionClient will eventually have garbage in m_cryptoConfig when it is constructed from temporary argument.